### PR TITLE
fixed wording comments in paper and in header

### DIFF
--- a/P2022/P2022R0.md
+++ b/P2022/P2022R0.md
@@ -55,7 +55,7 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 
 > ::: add
 > |    template <class T, class... U>
-> |    concept same-as-one-of = (same_as<T, U> or ...); // exposition only
+> |    concept same-as-one-of = /see below/; // exposition only
 > |
 > |    template<
 > |        input_iterator I1,
@@ -147,7 +147,7 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 
 > ::: add
 > |    template <class T, class... U>
-> |    concept same-as-one-of = /see below/; // exposition only
+> |    concept same-as-one-of = (same_as<T, U> or ...); // exposition only
 > |
 > |    template<
 > |        input_iterator I1,

--- a/P2022/P2022R0.md
+++ b/P2022/P2022R0.md
@@ -17,6 +17,8 @@ toc: false
 
 
 # Revision History
+    - R2
+        - Fixed wording accoring to mailing list comments
     - R1
         - Added link to github implementation
         - Added code example

--- a/P2022/P2022R0.md
+++ b/P2022/P2022R0.md
@@ -64,12 +64,7 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |        class Proj1,
 > |        class Proj2
 > |    >
-> |    using lexicographical-compare-three-way-result-t =
-> |        invoke_result_t<
-> |            Comp, 
-> |            class projected<I1, Proj1>::value_type, 
-> |            class projected<I2, Proj2>::value_type
-> |        >; // exposition-only
+> |    using lexicographical-compare-three-way-result-t = /see below/; // exposition-only
 > |
 > |     template<
 > |         input_iterator I1, sentinel_for<I1> S1,
@@ -78,12 +73,7 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |         class Proj1 = identity, 
 > |         class Proj2 = identity
 > |     >
-> |    constexpr bool is-lexicographical-compare-three-way-result-ordering =
-> |            same-as-one-of<
-> |                lexicographical-compare-three-way-result-t<
-> |                    I1, I2, Comp, Proj1, Proj2
-> |                >,
-> |                strong_ordering, weak_ordering, partial_ordering>; //exposition-only
+> |    constexpr bool is-lexicographical-compare-three-way-result-ordering = /see below/; //exposition-only
 > |
 > |    template<
 > |        input_iterator I1, sentinel_for<I1> S1,
@@ -156,7 +146,12 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |        class Proj1,
 > |        class Proj2
 > |    >
-> |    using lexicographical-compare-three-way-result-t = /see below/; // exposition-only
+> |    using lexicographical-compare-three-way-result-t =
+> |        invoke_result_t<
+> |            Comp, 
+> |            class projected<I1, Proj1>::value_type, 
+> |            class projected<I2, Proj2>::value_type
+> |        >; // exposition-only
 > |
 > |     template<
 > |         input_iterator I1, sentinel_for<I1> S1,
@@ -165,8 +160,12 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |         class Proj1 = identity, 
 > |         class Proj2 = identity
 > |     >
-> |    constexpr bool is-lexicographical-compare-three-way-result-ordering = /see below/; //exposition-only
-> |
+> |    constexpr bool is-lexicographical-compare-three-way-result-ordering = 
+> |            same-as-one-of<
+> |                lexicographical-compare-three-way-result-t<
+> |                    I1, I2, Comp, Proj1, Proj2
+> |                >,
+> |                strong_ordering, weak_ordering, partial_ordering>; //exposition-only
 > |    template<
 > |        input_iterator I1, sentinel_for<I1> S1,
 > |        input_iterator I2, sentinel_for<I2> S2,

--- a/P2022/P2022R0.md
+++ b/P2022/P2022R0.md
@@ -54,7 +54,7 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |                                        InputIterator2 b2, InputIterator2 e2);
 
 > ::: add
-> |    template <typename T, typename... U>
+> |    template <class T, class... U>
 > |    concept same-as-one-of = (same_as<T, U> or ...); // exposition only
 > |
 > |    template<
@@ -67,10 +67,17 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |    using lexicographical-compare-three-way-result-t =
 > |        invoke_result_t<
 > |            Comp, 
-> |            typename projected<I1, Proj1>::value_type, 
-> |            typename projected<I2, Proj2>::value_type
+> |            class projected<I1, Proj1>::value_type, 
+> |            class projected<I2, Proj2>::value_type
 > |        >; // exposition-only
 > |
+> |     template<
+> |         input_iterator I1, sentinel_for<I1> S1,
+> |         input_iterator I2, sentinel_for<I2> S2,
+> |         class Comp = compare_three_way,
+> |         class Proj1 = identity, 
+> |         class Proj2 = identity
+> |     >
 > |    constexpr bool is-lexicographical-compare-three-way-result-ordering =
 > |            same-as-one-of<
 > |                lexicographical-compare-three-way-result-t<
@@ -139,8 +146,8 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |                                       InputIterator2 b2, InputIterator2 e2);
 
 > ::: add
-> |    template <typename T, typename... U>
-> |    concept same-as-one-of = (same_as<T, U> or ...); // exposition only
+> |    template <class T, class... U>
+> |    concept same-as-one-of = /see below/; // exposition only
 > |
 > |    template<
 > |        input_iterator I1,
@@ -149,19 +156,16 @@ This document adds the wording for ```ranges::lexicographical_compare_three_way`
 > |        class Proj1,
 > |        class Proj2
 > |    >
-> |    using lexicographical-compare-three-way-result-t =
-> |        invoke_result_t<
-> |            Comp, 
-> |            typename projected<I1, Proj1>::value_type, 
-> |            typename projected<I2, Proj2>::value_type
-> |        >; // exposition-only
+> |    using lexicographical-compare-three-way-result-t = /see below/; // exposition-only
 > |
-> |    constexpr bool is-lexicographical-compare-three-way-result-ordering =
-> |            same-as-one-of<
-> |                lexicographical-compare-three-way-result-t<
-> |                    I1, I2, Comp, Proj1, Proj2
-> |                >,
-> |                strong_ordering, weak_ordering, partial_ordering>; //exposition-only
+> |     template<
+> |         input_iterator I1, sentinel_for<I1> S1,
+> |         input_iterator I2, sentinel_for<I2> S2,
+> |         class Comp = compare_three_way,
+> |         class Proj1 = identity, 
+> |         class Proj2 = identity
+> |     >
+> |    constexpr bool is-lexicographical-compare-three-way-result-ordering = /see below/; //exposition-only
 > |
 > |    template<
 > |        input_iterator I1, sentinel_for<I1> S1,

--- a/P2022/P2022R0.md
+++ b/P2022/P2022R0.md
@@ -2,7 +2,7 @@
 
 ---
 title: "Rangified version of lexicographical_compare_three_way"
-document: P2794R1
+document: P2794R2
 date: today
 audience: 
     - SG9

--- a/P2022/tests/header/3way.hpp
+++ b/P2022/tests/header/3way.hpp
@@ -7,8 +7,8 @@
 namespace std 
 {
     template <
-        typename T, 
-        typename... U
+        class T, 
+        class... U
     >
     concept same_as_any_of = (std::same_as<T, U> or ...); // exposition only
 }
@@ -25,8 +25,8 @@ namespace std::ranges
     using lexicographical_compare_three_way_result_t =
         invoke_result_t<
             Comp, 
-            typename projected<I1, Proj1>::value_type, 
-            typename projected<I2, Proj2>::value_type
+            class projected<I1, Proj1>::value_type, 
+            class projected<I2, Proj2>::value_type
         >; // exposition-only
 
     template<


### PR DESCRIPTION

1) [algorithm.syn]: The template head is missing for the variable template is-lexicographical-compare-three-way-result-ordering (Same problem in [alg.three.way]).

2) Same place: According to library conventions replace typename by class (E.g. same-as-one-of)

3) [algorithm.syn], [alg.three.way]: Don't provide duplicate definition of same-as-one-of. There are two choices: Either provide the definition in [algorithm.syn] only, or change the declaration in [algorithm.syn] to

template <typename T, typename... U>
concept same-as-one-of = /see below/;         // exposition only

and keep the definition in [alg.three.way].

Dito for lexicographical-compare-three-way-result-t and s-lexicographical-compare-three-way-result-ordering.
